### PR TITLE
Feature/multiple jjb lists

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -8,7 +8,7 @@
 # It sets the global ini file used by jenkins_job_builder
 #
 class jenkins_job_builder::config (
-  $jobs = $jenkins_job_builder::jobs,
+  $jobs = lookup('jenkins_job_builder::jobs', Optional[Hash], 'deep', $jenkins_job_builder::jobs),
   $user = $jenkins_job_builder::user,
   $password = $jenkins_job_builder::password,
   $timeout  = $jenkins_job_builder::timeout,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -53,7 +53,7 @@
 class jenkins_job_builder (
   $version                   = $jenkins_job_builder::params::version,
   Hash $defaults             = $jenkins_job_builder::params::defaults,
-  Hash $jobs                 = $jenkins_job_builder::params::jobs,
+  Hash $jobs                 = lookup('jenkins_job_builder::jobs', Optional[Hash], 'deep', $jenkins_job_builder::params::jobs),
   Optional[String] $user     = $jenkins_job_builder::params::user,
   Optional[String] $password = $jenkins_job_builder::params::password,
   Optional[Integer] $timeout = $jenkins_job_builder::params::timeout,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -53,7 +53,7 @@
 class jenkins_job_builder (
   $version                   = $jenkins_job_builder::params::version,
   Hash $defaults             = $jenkins_job_builder::params::defaults,
-  Hash $jobs                 = lookup('jenkins_job_builder::jobs', Optional[Hash], 'deep', $jenkins_job_builder::params::jobs),
+  Hash $jobs                 = $jenkins_job_builder::params::jobs,
   Optional[String] $user     = $jenkins_job_builder::params::user,
   Optional[String] $password = $jenkins_job_builder::params::password,
   Optional[Integer] $timeout = $jenkins_job_builder::params::timeout,


### PR DESCRIPTION
Allows the use of `jenkins_job_builder::jobs` in any part of the hierarchy to create jobs